### PR TITLE
Adding pointer event on forget password in sign-in form

### DIFF
--- a/src/components/signIn/login.js
+++ b/src/components/signIn/login.js
@@ -91,7 +91,7 @@ const LoginForm = () => {
                             </div>
                             <p className="error-text">{formErrors.password}</p>
                             <div className="forgot">
-                                Forgot password?
+                                <a href="#">Forgot password?</a> 
                             </div>
                             <button className="login-btn">Sign in</button>
                         </form>

--- a/src/styles/login.css
+++ b/src/styles/login.css
@@ -145,6 +145,12 @@ input:focus {
     font-family: sans-serif;
     font-size: small;
     margin-top: 0.2em;
+    cursor: pointer;
+}
+
+a{
+    text-decoration: none;
+    color: rgba(20, 102, 144, 1);
 }
 .login{
     /* background-color: blue; */


### PR DESCRIPTION
Resolved issue - #54
Update the pointer event at forgot password text on the sign-in page, and update it under the anchor tag for future link accessibility.
Merge this after reviewing,
Consider the changes under hacktoberfest'22.